### PR TITLE
fix: Replace deprecated safety check with pip-audit for dependency scanning

### DIFF
--- a/template-files/backend/requirements-dev.txt
+++ b/template-files/backend/requirements-dev.txt
@@ -17,6 +17,7 @@ pytest-mock>=3.12.0             # Mocking utilities
 pre-commit>=3.6.0               # Pre-commit hooks
 httpx>=0.27.0                   # HTTP client for testing
 
-# Optional: Additional quality tools
+# Security and Analysis Tools  
+pip-audit>=2.6.0                # Dependency vulnerability scanning
 bandit>=1.7.5                   # Security linting
 vulture>=2.11                   # Dead code detection

--- a/template-files/scripts/validate-adaptive.sh
+++ b/template-files/scripts/validate-adaptive.sh
@@ -445,18 +445,18 @@ validate_security() {
             # Handle virtual environments to avoid unintuitive audits
             if [[ -n "$VIRTUAL_ENV" ]]; then
                 # Already in activated virtual environment
-                pip_audit_cmd="PIP_PYTHON=\"$VIRTUAL_ENV/bin/python\" pip-audit"
-                pip_audit_fix_cmd="PIP_PYTHON=\"$VIRTUAL_ENV/bin/python\" pip-audit --desc"
+                pip_audit_cmd="PIPAPI_PYTHON_LOCATION=\"$VIRTUAL_ENV/bin/python\" pip-audit"
+                pip_audit_fix_cmd="PIPAPI_PYTHON_LOCATION=\"$VIRTUAL_ENV/bin/python\" pip-audit --desc"
             elif [[ -f ".venv/bin/python" ]]; then
                 # Virtual environment exists but not activated
                 local venv_python="$(pwd)/.venv/bin/python"
-                pip_audit_cmd="PIP_PYTHON=\"$venv_python\" pip-audit"
-                pip_audit_fix_cmd="PIP_PYTHON=\"$venv_python\" pip-audit --desc"
+                pip_audit_cmd="PIPAPI_PYTHON_LOCATION=\"$venv_python\" pip-audit"
+                pip_audit_fix_cmd="PIPAPI_PYTHON_LOCATION=\"$venv_python\" pip-audit --desc"
             elif [[ -f "venv/bin/python" ]]; then
                 # Alternative venv name
                 local venv_python="$(pwd)/venv/bin/python"
-                pip_audit_cmd="PIP_PYTHON=\"$venv_python\" pip-audit"
-                pip_audit_fix_cmd="PIP_PYTHON=\"$venv_python\" pip-audit --desc"
+                pip_audit_cmd="PIPAPI_PYTHON_LOCATION=\"$venv_python\" pip-audit"
+                pip_audit_fix_cmd="PIPAPI_PYTHON_LOCATION=\"$venv_python\" pip-audit --desc"
             fi
             
             run_validation "Python dependency scan" "$pip_audit_cmd" "pip-audit" "$pip_audit_fix_cmd && pip install --upgrade [vulnerable-packages]" || security_failed=true

--- a/template-files/scripts/validate-adaptive.sh
+++ b/template-files/scripts/validate-adaptive.sh
@@ -438,7 +438,28 @@ validate_security() {
     local has_python=$(read_config "project.structure.has_python")
     if [[ "$has_python" == "true" ]]; then
         if command -v pip-audit >/dev/null 2>&1; then
-            run_validation "Python dependency scan" "pip-audit" "pip-audit" "pip-audit --desc && pip install --upgrade [vulnerable-packages]" || security_failed=true
+            # Set up pip-audit to use the correct Python environment
+            local pip_audit_cmd="pip-audit"
+            local pip_audit_fix_cmd="pip-audit --desc"
+            
+            # Handle virtual environments to avoid unintuitive audits
+            if [[ -n "$VIRTUAL_ENV" ]]; then
+                # Already in activated virtual environment
+                pip_audit_cmd="PIP_PYTHON=\"$VIRTUAL_ENV/bin/python\" pip-audit"
+                pip_audit_fix_cmd="PIP_PYTHON=\"$VIRTUAL_ENV/bin/python\" pip-audit --desc"
+            elif [[ -f ".venv/bin/python" ]]; then
+                # Virtual environment exists but not activated
+                local venv_python="$(pwd)/.venv/bin/python"
+                pip_audit_cmd="PIP_PYTHON=\"$venv_python\" pip-audit"
+                pip_audit_fix_cmd="PIP_PYTHON=\"$venv_python\" pip-audit --desc"
+            elif [[ -f "venv/bin/python" ]]; then
+                # Alternative venv name
+                local venv_python="$(pwd)/venv/bin/python"
+                pip_audit_cmd="PIP_PYTHON=\"$venv_python\" pip-audit"
+                pip_audit_fix_cmd="PIP_PYTHON=\"$venv_python\" pip-audit --desc"
+            fi
+            
+            run_validation "Python dependency scan" "$pip_audit_cmd" "pip-audit" "$pip_audit_fix_cmd && pip install --upgrade [vulnerable-packages]" || security_failed=true
         elif command -v safety >/dev/null 2>&1; then
             # Fallback to safety (requires registration)
             run_validation "Python dependency scan" "safety scan" "safety" "safety scan --detailed-output && pip install --upgrade [vulnerable-packages]" || security_failed=true

--- a/template-files/scripts/validate-adaptive.sh
+++ b/template-files/scripts/validate-adaptive.sh
@@ -459,7 +459,7 @@ validate_security() {
                 pip_audit_fix_cmd="PIPAPI_PYTHON_LOCATION=\"$venv_python\" pip-audit --desc"
             fi
             
-            run_validation "Python dependency scan" "$pip_audit_cmd" "pip-audit" "$pip_audit_fix_cmd && pip install --upgrade [vulnerable-packages]" || security_failed=true
+            run_validation "Python dependency scan" "$pip_audit_cmd" "pip-audit" "# 1. Review vulnerabilities:\n$pip_audit_fix_cmd\n# 2. Fix automatically (but review first!):\npip-audit --fix\n# 3. Update requirements:\npip freeze > requirements.txt" || security_failed=true
         elif command -v safety >/dev/null 2>&1; then
             # Fallback to safety (requires registration)
             run_validation "Python dependency scan" "safety scan" "safety" "safety scan --detailed-output && pip install --upgrade [vulnerable-packages]" || security_failed=true


### PR DESCRIPTION
## Problem

The `safety check` command has been deprecated as of June 1, 2024, and the new `safety scan` command requires user registration/authentication, making it less user-friendly for automated quality checks.

## Solution

Replace the deprecated `safety` command with `pip-audit`, which:
- ✅ **No authentication required** - works out of the box
- ✅ **Maintained by Python Packaging Authority** - official and reliable  
- ✅ **Same functionality** - scans for known vulnerabilities
- ✅ **Better output** - clear, actionable vulnerability reports

## Changes

### 1. Updated validation script logic:


### 2. Added pip-audit to template requirements:


### 3. Improved fix commands:
- **pip-audit**: `pip-audit --desc && pip install --upgrade [vulnerable-packages]`
- **safety**: `safety scan --detailed-output && pip install --upgrade [vulnerable-packages]`

## Benefits

- **No user registration required** - works immediately after installation
- **More reliable automation** - won't prompt for login during CI/CD
- **Better user experience** - clear vulnerability descriptions
- **Backward compatibility** - still supports safety as fallback

## Migration Path

Users can install pip-audit with:
Requirement already satisfied: pip-audit in /Library/Frameworks/Python.framework/Versions/3.11/lib/python3.11/site-packages (2.9.0)
Collecting CacheControl>=0.13.0 (from CacheControl[filecache]>=0.13.0->pip-audit)
  Using cached cachecontrol-0.14.3-py3-none-any.whl.metadata (3.1 kB)
Collecting cyclonedx-python-lib<10,>=5 (from pip-audit)
  Using cached cyclonedx_python_lib-9.1.0-py3-none-any.whl.metadata (6.5 kB)
Requirement already satisfied: packaging>=23.0.0 in /Library/Frameworks/Python.framework/Versions/3.11/lib/python3.11/site-packages (from pip-audit) (25.0)
Requirement already satisfied: pip-api>=0.0.28 in /Library/Frameworks/Python.framework/Versions/3.11/lib/python3.11/site-packages (from pip-audit) (0.0.34)
Requirement already satisfied: pip-requirements-parser>=32.0.0 in /Library/Frameworks/Python.framework/Versions/3.11/lib/python3.11/site-packages (from pip-audit) (32.0.1)
Requirement already satisfied: requests>=2.31.0 in /Library/Frameworks/Python.framework/Versions/3.11/lib/python3.11/site-packages (from pip-audit) (2.32.4)
Requirement already satisfied: rich>=12.4 in /Library/Frameworks/Python.framework/Versions/3.11/lib/python3.11/site-packages (from pip-audit) (14.1.0)
Collecting toml>=0.10 (from pip-audit)
  Using cached toml-0.10.2-py2.py3-none-any.whl.metadata (7.1 kB)
Requirement already satisfied: platformdirs>=4.2.0 in /Library/Frameworks/Python.framework/Versions/3.11/lib/python3.11/site-packages (from pip-audit) (4.3.8)
Collecting license-expression<31,>=30 (from cyclonedx-python-lib<10,>=5->pip-audit)
  Using cached license_expression-30.4.4-py3-none-any.whl.metadata (11 kB)
Collecting packageurl-python<2,>=0.11 (from cyclonedx-python-lib<10,>=5->pip-audit)
  Using cached packageurl_python-0.17.5-py3-none-any.whl.metadata (5.1 kB)
Collecting py-serializable<3.0.0,>=2.0.0 (from cyclonedx-python-lib<10,>=5->pip-audit)
  Using cached py_serializable-2.1.0-py3-none-any.whl.metadata (4.3 kB)
Collecting sortedcontainers<3.0.0,>=2.4.0 (from cyclonedx-python-lib<10,>=5->pip-audit)
  Using cached sortedcontainers-2.4.0-py2.py3-none-any.whl.metadata (10 kB)
Collecting boolean.py>=4.0 (from license-expression<31,>=30->cyclonedx-python-lib<10,>=5->pip-audit)
  Using cached boolean_py-5.0-py3-none-any.whl.metadata (2.3 kB)
Collecting defusedxml<0.8.0,>=0.7.1 (from py-serializable<3.0.0,>=2.0.0->cyclonedx-python-lib<10,>=5->pip-audit)
  Using cached defusedxml-0.7.1-py2.py3-none-any.whl.metadata (32 kB)
Collecting msgpack<2.0.0,>=0.5.2 (from CacheControl>=0.13.0->CacheControl[filecache]>=0.13.0->pip-audit)
  Using cached msgpack-1.1.1-cp311-cp311-macosx_11_0_arm64.whl.metadata (8.4 kB)
Requirement already satisfied: filelock>=3.8.0 in /Library/Frameworks/Python.framework/Versions/3.11/lib/python3.11/site-packages (from CacheControl[filecache]>=0.13.0->pip-audit) (3.18.0)
Requirement already satisfied: pip in /Library/Frameworks/Python.framework/Versions/3.11/lib/python3.11/site-packages (from pip-api>=0.0.28->pip-audit) (25.2)
Collecting pyparsing (from pip-requirements-parser>=32.0.0->pip-audit)
  Using cached pyparsing-3.2.3-py3-none-any.whl.metadata (5.0 kB)
Requirement already satisfied: charset_normalizer<4,>=2 in /Library/Frameworks/Python.framework/Versions/3.11/lib/python3.11/site-packages (from requests>=2.31.0->pip-audit) (3.4.3)
Requirement already satisfied: idna<4,>=2.5 in /Library/Frameworks/Python.framework/Versions/3.11/lib/python3.11/site-packages (from requests>=2.31.0->pip-audit) (3.10)
Requirement already satisfied: urllib3<3,>=1.21.1 in /Library/Frameworks/Python.framework/Versions/3.11/lib/python3.11/site-packages (from requests>=2.31.0->pip-audit) (2.5.0)
Requirement already satisfied: certifi>=2017.4.17 in /Library/Frameworks/Python.framework/Versions/3.11/lib/python3.11/site-packages (from requests>=2.31.0->pip-audit) (2025.8.3)
Requirement already satisfied: markdown-it-py>=2.2.0 in /Library/Frameworks/Python.framework/Versions/3.11/lib/python3.11/site-packages (from rich>=12.4->pip-audit) (3.0.0)
Requirement already satisfied: pygments<3.0.0,>=2.13.0 in /Library/Frameworks/Python.framework/Versions/3.11/lib/python3.11/site-packages (from rich>=12.4->pip-audit) (2.19.2)
Requirement already satisfied: mdurl~=0.1 in /Library/Frameworks/Python.framework/Versions/3.11/lib/python3.11/site-packages (from markdown-it-py>=2.2.0->rich>=12.4->pip-audit) (0.1.2)
Using cached cyclonedx_python_lib-9.1.0-py3-none-any.whl (374 kB)
Using cached license_expression-30.4.4-py3-none-any.whl (120 kB)
Using cached packageurl_python-0.17.5-py3-none-any.whl (30 kB)
Using cached py_serializable-2.1.0-py3-none-any.whl (23 kB)
Using cached defusedxml-0.7.1-py2.py3-none-any.whl (25 kB)
Using cached sortedcontainers-2.4.0-py2.py3-none-any.whl (29 kB)
Using cached boolean_py-5.0-py3-none-any.whl (26 kB)
Using cached cachecontrol-0.14.3-py3-none-any.whl (21 kB)
Using cached msgpack-1.1.1-cp311-cp311-macosx_11_0_arm64.whl (79 kB)
Using cached toml-0.10.2-py2.py3-none-any.whl (16 kB)
Using cached pyparsing-3.2.3-py3-none-any.whl (111 kB)
Installing collected packages: sortedcontainers, boolean.py, toml, pyparsing, packageurl-python, msgpack, license-expression, defusedxml, py-serializable, CacheControl, cyclonedx-python-lib

Successfully installed CacheControl-0.14.3 boolean.py-5.0 cyclonedx-python-lib-9.1.0 defusedxml-0.7.1 license-expression-30.4.4 msgpack-1.1.1 packageurl-python-0.17.5 py-serializable-2.1.0 pyparsing-3.2.3 sortedcontainers-2.4.0 toml-0.10.2

Or it will be included automatically in new projects via requirements-dev.txt.

## Testing

Tested with various Python projects - pip-audit provides clear, actionable vulnerability reports without requiring authentication.